### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ defaults:
 jobs:
   lint:
     name: lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.


### PR DESCRIPTION
Potential fix for [https://github.com/nephelaiio/ansible-role-metricbeat/security/code-scanning/5](https://github.com/nephelaiio/ansible-role-metricbeat/security/code-scanning/5)

To fix this problem, add a `permissions` block either at the workflow root level (to apply to all jobs) or under the specific job (here: `lint`). The minimal required permissions for linting jobs that check out code and run local test/lint commands are `contents: read`, so restrict the GITHUB_TOKEN to read-only access to repository contents. Since the workflow does not appear to need other kinds of write or read permissions (such as to issues, deployments, or workflows), no further permissions should be granted. The fix can be applied either directly under the top-level keys, or inside the `lint` job definition. Since the workflow only has one job, it is preferable to set it at the job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
